### PR TITLE
Improve Slider Checkbox Visibility

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -1199,6 +1199,11 @@ settings:
     --ctp-crust: var(--ctp-ext-crust, 220, 224, 232);
   }
 
+  /* Slider checkboxes for Style Settings */
+  .checkbox-container.is-enabled:after {
+    background-color: var(--background-primary);
+  }
+
   /* Callouts */
 
   .callout,


### PR DESCRIPTION
Improve slider checkbox visibility in Style Settings by inverting the color when toggled on. The current version is hard to see when toggled on since it is white. This version just makes it the background color (dark). Taken from AnuPpuccin.